### PR TITLE
Update streamflow.bat

### DIFF
--- a/streamflow-dist/src/main/resources/bin/streamflow.bat
+++ b/streamflow-dist/src/main/resources/bin/streamflow.bat
@@ -3,25 +3,24 @@
 SETLOCAL
 
 rem Change this value to modify any JAVA_OPTS provided to the Streamflow server
-set STREAMFLOW_OPTS="-Xms256m -Xmx256g"
+set STREAMFLOW_OPTS=-Xms256m -Xmx256m
 
 if NOT DEFINED JAVA_HOME goto err
 
 set SCRIPT_DIR=%~dp0
-for %%I in ("%SCRIPT_DIR%..") 
-    do set STREAMFLOW_HOME=%%~dpfI
+for %%I in ("%SCRIPT_DIR%..") do set STREAMFLOW_HOME=%%~dpfI
 
 TITLE Streamflow Server ${project.version}
 
-echo
-echo "Streamflow Server ${project.version}"
-echo
-echo " JAVA_HOME:        %JAVA_HOME%"
-echo " JAVA:             %JAVA_HOME%\bin\java"
-echo " STREAMFLOW_HOME:  %STREAMFLOW_HOME%"
-echo
+echo.
+echo Streamflow Server ${project.version}
+echo.
+echo JAVA_HOME:        %JAVA_HOME%
+echo JAVA:             %JAVA_HOME%\bin\java
+echo STREAMFLOW_HOME:  %STREAMFLOW_HOME%
+echo.
 
-"%JAVA_HOME%\bin\java" %JAVA_OPTS% %STREAMFLOW_OPTS% -cp %STREAMFLOW_HOME%\lib -jar^
+"%JAVA_HOME%\bin\java" %STREAMFLOW_OPTS% -cp %STREAMFLOW_HOME%\lib -jar^
      %STREAMFLOW_HOME%\lib\streamflow-app-jar-${project.version}.jar
 
 goto finally


### PR DESCRIPTION
The original batch does not work due to the for loop not having do on the same line, and other errors. Added are fixes. The new version is fully tested and works on Windows 7.
